### PR TITLE
Generate migrations for table creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+migrations

--- a/bin/flock
+++ b/bin/flock
@@ -28,6 +28,7 @@ rollback [lastId]
 latest
 
 Arguments:
+--new-table
 --options file.json
 --help
 `
@@ -62,7 +63,7 @@ if (args[0] === 'create') {
 
       if (fileName) {
         const r = fs.createReadStream(path.resolve(__dirname, '../templates/migration.js'))
-        const w = fs.createWriteStream(fileName)
+        const w = fs.createWriteStream(path.resolve(__dirname, `../migrations/${fileName}`))
         r.pipe(w)
         r.on('end', () => {
           process.exit(0)

--- a/bin/flock
+++ b/bin/flock
@@ -44,18 +44,34 @@ if (args.find(x => x === '--help')) {
 if (args[0] === 'create') {
   const fileName = args[1]
 
-  // NOTE: We'll need to support creating migrartions for specific plugins perhaps?
+  // migration which creates a new table
+  if (args.find(x => x === '--new-table')) {
 
-  if (fileName) {
-    const r = fs.createReadStream(path.resolve(__dirname, '../templates/migration.js'))
-    const w = fs.createWriteStream(fileName)
-    r.pipe(w)
-    r.on('end', () => {
-      process.exit(0)
-    })
+    if (fileName) {
+      const blah = 'asdfghjkl'
+
+      const r = fs.createReadStream(path.resolve(__dirname, '../templates/create-table.js'))
+      const w = fs.createWriteStream(path.resolve(__dirname, `../migrations/${fileName}`))
+      r.pipe(w)
+      r.on('end', () => {
+        process.exit(0)
+      })
+    }
   } else {
-    throw new Error('Create command requires a migration file name.')
+      // NOTE: We'll need to support creating migrartions for specific plugins perhaps?
+
+      if (fileName) {
+        const r = fs.createReadStream(path.resolve(__dirname, '../templates/migration.js'))
+        const w = fs.createWriteStream(fileName)
+        r.pipe(w)
+        r.on('end', () => {
+          process.exit(0)
+        })
+      } else {
+        throw new Error('Create command requires a migration file name.')
+      }
   }
+ 
 // Handle all other commands (i.e. pass them to flock)
 } else {
   // Handle the --options argument

--- a/bin/flock
+++ b/bin/flock
@@ -47,10 +47,7 @@ if (args[0] === 'create') {
 
   // migration which creates a new table
   if (args.find(x => x === '--new-table')) {
-
     if (fileName) {
-      const blah = 'asdfghjkl'
-
       const r = fs.createReadStream(path.resolve(__dirname, '../templates/create-table.js'))
       const w = fs.createWriteStream(path.resolve(__dirname, `../migrations/${fileName}`))
       r.pipe(w)
@@ -59,18 +56,17 @@ if (args[0] === 'create') {
       })
     }
   } else {
-      // NOTE: We'll need to support creating migrartions for specific plugins perhaps?
-
-      if (fileName) {
-        const r = fs.createReadStream(path.resolve(__dirname, '../templates/migration.js'))
-        const w = fs.createWriteStream(path.resolve(__dirname, `../migrations/${fileName}`))
-        r.pipe(w)
-        r.on('end', () => {
-          process.exit(0)
-        })
-      } else {
-        throw new Error('Create command requires a migration file name.')
-      }
+    // NOTE: We'll need to support creating migrartions for specific plugins perhaps?
+    if (fileName) {
+      const r = fs.createReadStream(path.resolve(__dirname, '../templates/migration.js'))
+      const w = fs.createWriteStream(path.resolve(__dirname, `../migrations/${fileName}`))
+      r.pipe(w)
+      r.on('end', () => {
+        process.exit(0)
+      })
+    } else {
+      throw new Error('Create command requires a migration file name.')
+    }
   }
  
 // Handle all other commands (i.e. pass them to flock)

--- a/templates/create-table.js
+++ b/templates/create-table.js
@@ -1,4 +1,4 @@
-console.warn('fdsdfsdf')/*
+/*
 SQL Snippets:
 
 See: https://www.postgresql.org/docs/10/static/sql-createtable.html

--- a/templates/create-table.js
+++ b/templates/create-table.js
@@ -1,0 +1,101 @@
+console.warn('fdsdfsdf')/*
+SQL Snippets:
+
+See: https://www.postgresql.org/docs/10/static/sql-createtable.html
+
+  CREATE TABLE IF NOT EXISTS "TableName" (
+    id SERIAL,
+    created_at timestamp with time zone DEFAULT current_timestamp,
+    modified_at timestamp with time zone,
+    key text,
+    ...
+    PRIMARY KEY (id),
+    FOREIGN KEY (text)
+      REFERENCES "OtherTable" (text)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+  )
+
+See: https://www.postgresql.org/docs/10/static/sql-altertable.html
+
+  ALTER TABLE IF EXISTS "TableName"
+    ADD COLUMN IF NOT EXISTS my_col integer
+    ADD PRIMARY KEY (my_col)
+    DROP COLUMN IF EXISTS other_col
+    ALTER COLUMN some_col TYPE varchar(1024)
+
+See: https://www.postgresql.org/docs/10/static/sql-droptable.html
+
+  DROP TABLE IF EXISTS "TableName"
+
+*/
+
+/*
+See: https://www.postgresql.org/docs/10/static/datatype.html
+
+Common Data Types:
+
+smallint
+integer
+bigint
+smallserial
+serial
+bigserial
+numeric
+numeric(precision, scale) i.e. NUMERIC(4, 2) (4 digits left and right of decimal, only 2 digits permitted on right of decimal)
+real
+double precision
+money
+text
+varchar(length)
+char(length) (blank padded)
+timestamp
+timestamp with time zone
+date
+time
+time with time zone
+interval
+boolean
+jsonb
+
+See: https://www.postgresql.org/docs/10/static/datatype-enum.html
+
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+*/
+
+/*
+Context Methods:
+
+tableExists(tableName): Promise<boolean>
+columnExists(tableName, columnName): Promise<boolean>
+columnDataType(tableName, columnName): Promise<string|null>
+inspectColumn(tableName, columnName): Promise<{}>
+*/
+
+exports.up = function (context) {
+  const { client } = context
+  const query =
+`CREATE TABLE IF NOT EXISTS "TableName" (
+  id SERIAL,
+  created_at timestamp with time zone DEFAULT current_timestamp,
+  modified_at timestamp with time zone,
+  key text,
+  ...
+  PRIMARY KEY (id),
+  FOREIGN KEY (text)
+    REFERENCES "OtherTable" (text)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+)`
+
+  return client.query(query)
+}
+
+exports.down = function (context) {
+  const { client } = context
+  const query =
+`DROP TABLE IF EXISTS "TableName"`
+
+  return client.query(query)
+}


### PR DESCRIPTION
- With the --new-table arg, generate from a template with the table creation SQL code already in the file.

- Fix the migration generation which was targeting the root folder