### PR TITLE
Handle promise rejection in CLI

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -20,7 +20,10 @@ function initProgram () {
     .description('Create a database migration')
     .option('-c, --config', 'The config file to load (default .flockrc.json)')
     .action((cmd) => {
-      actions.create({ cfgFileName: cmd.config })
+      actions.create({ cfgFileName: cmd.config }).catch(error => {
+        console.error(error)
+        process.exit(1)
+      })
     })
 
   program
@@ -33,7 +36,10 @@ function initProgram () {
       if (cmd.require) {
         require(cmd.require)
       }
-      actions.migrate({ migrationId, list: cmd.list, cfgFileName: cmd.config })
+      actions.migrate({ migrationId, list: cmd.list, cfgFileName: cmd.config }).catch(error => {
+        console.error(error)
+        process.exit(1)
+      })
     })
 
   program
@@ -47,7 +53,10 @@ function initProgram () {
       if (cmd.require) {
         require(cmd.require)
       }
-      actions.rollback({ migrationId, list: cmd.list, cfgFileName: cmd.config })
+      actions.rollback({ migrationId, list: cmd.list, cfgFileName: cmd.config }).catch(error => {
+        console.error(error)
+        process.exit(1)
+      })
     })
 
   program
@@ -55,7 +64,10 @@ function initProgram () {
     .description('Upgrade a flock project using a .yo-rc.json file to use a .flockrc.json file')
     .option('-c, --config', 'The config file to write to (default .flockrc.json)')
     .action((cmd) => {
-      actions.upgrade({ cfgFileName: cmd.config })
+      actions.upgrade({ cfgFileName: cmd.config }).catch(error => {
+        console.error(error)
+        process.exit(1)
+      })
     })
 
   program


### PR DESCRIPTION
Add .catch() to all async CLI commands and exit the process with error code 1.
This is so that when migrations fail or any CLI action fails the process is
terminated with an error code so that deployments fail.

Closes #13 